### PR TITLE
Added support of different tsc.js path for 1.6 prerelase Typescript

### DIFF
--- a/lib/typescript-src.rb
+++ b/lib/typescript-src.rb
@@ -27,7 +27,12 @@ module TypeScript
 
       # @return [Pathname]
       def js_path
-        typescript_path.join('bin/tsc.js')
+        bin_tsc = typescript_path.join('bin/tsc.js')
+        if ::File.exist?(bin_tsc)
+          bin_tsc
+        else
+          typescript_path.join('lib/tsc.js')
+        end
       end
 
       # @return [Pathname]


### PR DESCRIPTION
In current prerelase version tsc.js was moved from bin to lib, see https://github.com/Microsoft/TypeScript/pull/4039